### PR TITLE
Sign-up Form Structure

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
 import './globals.css'
+import Header from '@/components/Header/Header'
 
 const inter = Inter({ subsets: ['latin'] })
 
@@ -16,7 +17,12 @@ export default function RootLayout ({
 }) {
   return (
     <html lang='es'>
-      <body className={inter.className}>{children}</body>
+      <body className={inter.className}>
+        <Header />
+        <div className='pt-16'>
+          {children}
+        </div>
+      </body>
     </html>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,7 @@
-import Header from '@/components/Header/Header'
-
 export default function Home () {
   return (
     <>
-      <Header />
+      <h2>Home de la Aplicación</h2>
     </>
   )
 }

--- a/app/sign-up/page.tsx
+++ b/app/sign-up/page.tsx
@@ -1,0 +1,46 @@
+import FieldContainer from '@/components/Form/FieldContainer'
+import FormContainer from '@/components/Form/FormContainer'
+import Input from '@/components/Form/Input'
+import Label from '@/components/Form/Label'
+import SendData from '@/components/Form/SendData'
+import Link from 'next/link'
+
+export default function SignUp () {
+  return (
+    <FormContainer>
+      <h2 className="text-center text-lg self-center">Registrarse en Red Mascotera</h2>
+      <section className="flex items-center justify-center">
+        <form className="bg-slate-500 p-4 w-1/2 grid grid-cols-2 rounded-md h-[400px] gap-4">
+          <FieldContainer>
+            <Label htmlFor="name">Nombre</Label>
+            <Input type="text" />
+          </FieldContainer>
+          <FieldContainer>
+            <Label htmlFor="apellido">Apellido</Label>
+            <Input type="text" />
+          </FieldContainer>
+          <FieldContainer className="col-span-2">
+            <Label htmlFor="email">Correo Electrónico</Label>
+            <Input type="email" />
+          </FieldContainer>
+          <FieldContainer>
+            <Label htmlFor="username">Nombre de usuario</Label>
+            <Input type="text" />
+          </FieldContainer>
+          <FieldContainer>
+            <Label htmlFor="contraseña">Contraseña</Label>
+            <Input type="password" />
+          </FieldContainer>
+          <FieldContainer className="col-span-2 flex items-center justify-center">
+            <SendData label='Registrarse'/>
+          </FieldContainer>
+        </form>
+      </section>
+      <section className='flex justify-center self-center'>
+        <p>
+          Ya tienes una cuenta creada? Inicia sesión <Link href="/sign-in" className='underline rounded-sm'>aquí</Link>
+        </p>
+      </section>
+    </FormContainer>
+  )
+}

--- a/app/sign-up/page.tsx
+++ b/app/sign-up/page.tsx
@@ -4,13 +4,14 @@ import Input from '@/components/Form/Input'
 import Label from '@/components/Form/Label'
 import SendData from '@/components/Form/SendData'
 import Link from 'next/link'
+import styles from '@/components/Form/Form.module.css'
 
 export default function SignUp () {
   return (
     <FormContainer>
-      <h2 className="text-center text-lg self-center">Registrarse en Red Mascotera</h2>
+      <h2 className={'text-center text-lg self-center ' + styles.formTitle}>Registrarse en Red Mascotera</h2>
       <section className="flex items-center justify-center">
-        <form className="bg-slate-500 p-4 w-1/2 grid grid-cols-2 rounded-md h-[400px] gap-4">
+        <form className={'bg-slate-500 p-4 min-w-[25rem] grid grid-cols-2 rounded-md h-[400px] gap-4 ' + styles.form}>
           <FieldContainer>
             <Label htmlFor="name">Nombre</Label>
             <Input type="text" />
@@ -31,13 +32,13 @@ export default function SignUp () {
             <Label htmlFor="contraseña">Contraseña</Label>
             <Input type="password" />
           </FieldContainer>
-          <FieldContainer className="col-span-2 flex items-center justify-center">
+          <FieldContainer className='col-span-2 flex items-center justify-center'>
             <SendData label='Registrarse'/>
           </FieldContainer>
         </form>
       </section>
       <section className='flex justify-center self-center'>
-        <p>
+        <p className={styles.formFooter}>
           Ya tienes una cuenta creada? Inicia sesión <Link href="/sign-in" className='underline rounded-sm'>aquí</Link>
         </p>
       </section>

--- a/components/Form/FieldContainer.tsx
+++ b/components/Form/FieldContainer.tsx
@@ -1,0 +1,10 @@
+export default function FieldContainer ({ children, className }: {
+  children: React.ReactNode
+  className?: string
+}) {
+  return (
+    <div className={'flex flex-col justify-center gap-2 ' + className}>
+        {children}
+    </div>
+  )
+}

--- a/components/Form/Form.module.css
+++ b/components/Form/Form.module.css
@@ -1,0 +1,86 @@
+@media (max-width: 280px){
+    .formContainer{
+        grid-template-rows: 3rem 1fr 4rem;
+    }
+
+    .formTitle,
+    .formFooter{
+        font-size: .9rem;
+        text-align: center;
+    }
+
+    .form{
+        min-width: 0;
+        width: 100%;
+        background: none;
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+        gap: .5rem;
+    }
+
+    .label{
+        font-size: .85rem;
+    }
+
+    .input{
+        padding: .25rem .5rem;
+    }
+}
+
+@media (max-width: 430px){
+    .sendButton{
+        padding: .35rem .5rem;
+        font-size: .95rem;
+        background: rgb(226, 232, 240);
+        color: #444;
+    }
+}
+
+@media (min-width: 281px) and (max-width: 430px){
+    .form{
+        min-width: 0;
+        width: 100%;
+        padding: .5rem 1rem;
+        background: none;
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        justify-content: space-around;
+    }
+
+    .label{
+        font-size: .9rem;
+    }
+
+    .input{
+        padding: .25rem .5rem;
+    }
+
+    .formFooter{
+        font-size: .85rem;
+    }
+}
+
+@media (min-width: 768px) and (min-height:769px) and (max-height: 1368px){
+    .formTitle,
+    .formFooter{
+        font-size: 1.5rem;
+    }
+
+    .form{
+        min-width: 0;
+        width: 80%;
+        height: 75%;
+        padding: 2rem;
+    }
+
+    .label{
+        font-size: 1.5rem;
+    }
+
+    .sendButton{
+        font-size: 1.25rem;
+    }
+}

--- a/components/Form/FormContainer.tsx
+++ b/components/Form/FormContainer.tsx
@@ -1,0 +1,9 @@
+export default function FormContainer ({ children }: {
+  children: React.ReactNode
+}) {
+  return (
+    <main className="grid grid-rows-[4rem,1fr,4rem] min-h-[calc(100vh-4rem)]">
+        {children}
+    </main>
+  )
+}

--- a/components/Form/FormContainer.tsx
+++ b/components/Form/FormContainer.tsx
@@ -1,8 +1,10 @@
+import styles from '@/components/Form/Form.module.css'
+
 export default function FormContainer ({ children }: {
   children: React.ReactNode
 }) {
   return (
-    <main className="grid grid-rows-[4rem,1fr,4rem] min-h-[calc(100vh-4rem)]">
+    <main className={'grid grid-rows-[4rem,1fr,4rem] min-h-[calc(100vh-4rem)] ' + styles.formContainer}>
         {children}
     </main>
   )

--- a/components/Form/Input.tsx
+++ b/components/Form/Input.tsx
@@ -1,10 +1,12 @@
+import styles from '@/components/Form/Form.module.css'
+
 export default function Input ({ type }: {
   type: string
 }) {
   return (
     <input
     type={type}
-    className="rounded focus:outline-none text-red-300 px-2 py-1 focus:bg-orange-50"
+    className={'rounded focus:outline-none text-red-300 px-2 py-1 focus:bg-orange-50 ' + styles.input}
     />
   )
 }

--- a/components/Form/Input.tsx
+++ b/components/Form/Input.tsx
@@ -1,0 +1,10 @@
+export default function Input ({ type }: {
+  type: string
+}) {
+  return (
+    <input
+    type={type}
+    className="rounded focus:outline-none text-red-300 px-2 py-1 focus:bg-orange-50"
+    />
+  )
+}

--- a/components/Form/Label.tsx
+++ b/components/Form/Label.tsx
@@ -1,0 +1,10 @@
+export default function Label ({ children, htmlFor }: {
+  children: React.ReactNode
+  htmlFor: string
+}) {
+  return (
+    <label htmlFor={htmlFor} className="text-lg">
+      {children}
+    </label>
+  )
+}

--- a/components/Form/Label.tsx
+++ b/components/Form/Label.tsx
@@ -1,9 +1,11 @@
+import styles from '@/components/Form/Form.module.css'
+
 export default function Label ({ children, htmlFor }: {
   children: React.ReactNode
   htmlFor: string
 }) {
   return (
-    <label htmlFor={htmlFor} className="text-lg">
+    <label htmlFor={htmlFor} className={'text-lg ' + styles.label}>
       {children}
     </label>
   )

--- a/components/Form/SendData.tsx
+++ b/components/Form/SendData.tsx
@@ -1,8 +1,10 @@
+import styles from '@/components/Form/Form.module.css'
+
 export default function SendData ({ label }: { label: string }) {
   return (
     <input
     type="submit"
-    className="cursor-pointer bg-slate-600 py-2 px-4 rounded hover:bg-slate-400"
+    className={'cursor-pointer bg-slate-600 py-2 px-4 rounded hover:bg-slate-400 transition-all ' + styles.sendButton}
     value={label}
     />
   )

--- a/components/Form/SendData.tsx
+++ b/components/Form/SendData.tsx
@@ -1,0 +1,9 @@
+export default function SendData ({ label }: { label: string }) {
+  return (
+    <input
+    type="submit"
+    className="cursor-pointer bg-slate-600 py-2 px-4 rounded hover:bg-slate-400"
+    value={label}
+    />
+  )
+}

--- a/components/Header/Header.jsx
+++ b/components/Header/Header.jsx
@@ -3,16 +3,19 @@ import Image from 'next/image'
 import styles from '@/components/Header/Header.module.css'
 import NavLinks from './NavLinks'
 import ResponsiveNavBar from './ResponsiveNavBar'
+import Link from 'next/link'
 
 export default function Header () {
   return (
     <header className={'h-16 flex items-center justify-around bg-slate-200 text-slate-700 gap-5 px-5 fixed w-full ' + styles.header}>
       <h1 className={'text-center w-60 font-medium text-xl uppercase text-yellow-700 ' + styles.title}>Red Mascotera</h1>
-      <Image
-        src={logo}
-        alt='A puppy with a heart in his eyes'
-        className={'w-auto h-full ' + styles.logo}
-      />
+      <Link href="/" className={'w-auto h-full'} >
+        <Image
+          src={logo}
+          alt='A puppy with a heart in his eyes'
+          className={'w-auto h-full ' + styles.logo}
+        />
+      </Link>
       <nav className={'flex items-center justify-between w-full ' + styles.navBar}>
         <NavLinks />
       </nav>

--- a/components/Header/NavLinks.jsx
+++ b/components/Header/NavLinks.jsx
@@ -20,7 +20,7 @@ export default function NavLinks () {
     <LinkToVisit href={'#contact'}>Contacto</LinkToVisit>
     <LinkToVisit href={'#pet-lost'}>Perdí a mi Mascota</LinkToVisit>
     <LinkToVisit href={'#pet-adoption'}>Adopción</LinkToVisit>
-    <LinkToVisit href={'#'} className={'text-red-300 hover:text-red-400'}>Mi Perfil</LinkToVisit>
+    <LinkToVisit href={'/sign-up'} className={'text-red-300 hover:text-red-400'}>Mi Perfil</LinkToVisit>
     </>
   )
 }


### PR DESCRIPTION
- Added sign-up form structure, which involves html and css only.
- Media queries for responsive were included in the CSSModule file.
- New route "/sign-up" on NextJS proyect.

![signUpPage-url](https://github.com/redmascotera/redmascotera-front/assets/131391947/44b5331a-58f9-40e6-bd8c-c241414cc72c)

- Created different components such as `<Label />`, `<Input />`, `<sendData />`; so as to organize and reuse the code and styles in the following sign-in form.

![signUpForm-screen-desktop](https://github.com/redmascotera/redmascotera-front/assets/131391947/bad1c6d5-130d-413c-8a4e-3f4fe852f812)

- The `<Header />` component is kept in all the pages that are visited ( it´s within the root layout in NextJS ).

![header-home-signUp-desktop](https://github.com/redmascotera/redmascotera-front/assets/131391947/19b714bc-6bb0-4c4b-a2b6-8c02118475dc)

#### Previews

- Desktop (height: 768px)

![signUp-screen-desktop](https://github.com/redmascotera/redmascotera-front/assets/131391947/ca21d1e8-b3de-4a78-b7a2-94858c5053d8)

- iPad Mini

![signUp-screen-IpadMini](https://github.com/redmascotera/redmascotera-front/assets/131391947/8a5d7edd-e22a-4af5-8e36-a5728d615263)

- Galaxy S8+

![signUp-screen-galaxyS8Plus](https://github.com/redmascotera/redmascotera-front/assets/131391947/df7c46ee-699b-408e-95a4-40f2df085602)

- Galaxy Fold (max-height: 280px)

![signUp-screen-galaxyFold](https://github.com/redmascotera/redmascotera-front/assets/131391947/13035982-4dca-4633-b015-9a9fcc235fb9)
