### PR TITLE
Sign-in Form Structure

### DIFF
--- a/app/sign-in/page.tsx
+++ b/app/sign-in/page.tsx
@@ -1,0 +1,35 @@
+import FieldContainer from '@/components/Form/FieldContainer'
+import FormContainer from '@/components/Form/FormContainer'
+import Input from '@/components/Form/Input'
+import Label from '@/components/Form/Label'
+import styles from '@/components/Form/Form.module.css'
+import Link from 'next/link'
+import SendData from '@/components/Form/SendData'
+
+export default function SignIn () {
+  return (
+    <FormContainer>
+        <h2 className={'text-center text-lg self-center ' + styles.formTitle}>Iniciar Sesión en Red Mascotera</h2>
+        <section className="flex items-center justify-center">
+            <form className={'bg-slate-500 p-4 min-w-[25rem] rounded-md h-[400px] gap-16 flex flex-col justify-center ' + `${styles.form} ${styles.formSignIn}`}>
+                <FieldContainer>
+                    <Label htmlFor="email">Correo Electrónico</Label>
+                    <Input type="email" />
+                </FieldContainer>
+                <FieldContainer>
+                    <Label htmlFor='password'>Contraseña</Label>
+                    <Input type='password'/>
+                </FieldContainer>
+                <FieldContainer className='col-span-2 flex items-center justify-center'>
+                    <SendData label='Iniciar Sesión'/>
+                </FieldContainer>
+            </form>
+        </section>
+        <section className='flex justify-center self-center'>
+            <p className={styles.formFooter}>
+                No tienes una cuenta? Registrate <Link href="/sign-up" className='underline rounded-sm'>aquí</Link>
+            </p>
+      </section>
+    </FormContainer>
+  )
+}

--- a/components/Form/Form.module.css
+++ b/components/Form/Form.module.css
@@ -84,3 +84,8 @@
         font-size: 1.25rem;
     }
 }
+
+.formSignIn{
+    justify-content: center;
+    gap: 4rem;
+}


### PR DESCRIPTION
- Added sign-in form.

![signInPage-url](https://github.com/redmascotera/redmascotera-front/assets/131391947/fcf4c37e-18d6-4c7a-ae74-3c683fe12a9a)

- Responsive design reused from the sign-up components.

#### Previews

- Desktop (height: 768px)

![desktop-signInPage](https://github.com/redmascotera/redmascotera-front/assets/131391947/b461fda5-84db-4aff-8fdd-f1c3f0add156)

- Galaxy A51/A71

![galaxyA51-A57-signInPage](https://github.com/redmascotera/redmascotera-front/assets/131391947/706c33f9-69b8-4e53-be66-be80137479b5)
